### PR TITLE
Fixed #7 - Error message from O365 had changed

### DIFF
--- a/core/sprayers/lync.py
+++ b/core/sprayers/lync.py
@@ -117,13 +117,15 @@ class Lync:
         if 'Invalid STS request' in msg:
             log.error(print_bad('Invalid request was received by server, dumping request & response XML'))
             log.error(soap + '\n' + r.text)
-        elif ('To sign into this application the account must be added' in msg) or ("The user account does not exist" in msg):
+        elif ('the account must be added' in msg) or ("The user account does not exist" in msg):
             log.info(print_bad(f"Authentication failed: {username}:{password} (Username does not exist)"))
         elif 'Error validating credentials' in msg:
             log.info(print_bad(f"Authentication failed: {username}:{password} (Invalid credentials)"))
         elif 'you must use multi-factor' in msg.lower():
             log.info(print_good(f"Found Credentials: {username}:{password} (However, MFA is required)"))
             self.valid_accounts.add(username)
+        elif 'No tenant-identifying information found' in msg:
+            log.info(print_bad(f"Authentication failed: {username}:{password} (No tenant-identifying information found)"))
         else:
             log.info(print_good(f"Found credentials: {username}:{password}"))
             self.valid_accounts.add(username)


### PR DESCRIPTION
This pull request should fix issue #7 where all accounts that do not exist are considered as valid.

O365 changed the error message from "To sign into this application the account must be added" to "To sign into this application, the account must be added". To avoid breaking the application if small changes are made to the text, I made it a bit more generic by removing part of the sentence.

I also added another use case that could happens while spraying. If you try to use a "test@anotherdomain.com" account while spraying for the "mydomain.com" domain, O365 will return a different error message and the application will say the account is valid. To handle this use case, I added another check.