### PR TITLE
fix: Unregister signal handlers while waiting for intervals. Closes #9.

### DIFF
--- a/core/utils/time.py
+++ b/core/utils/time.py
@@ -25,10 +25,15 @@ def countdown_timer(hours, minutes, seconds, now=datetime.now):
     target = now()
 
     one_second_later = timedelta(seconds=1)
-    for remaining in range(int(delay.total_seconds()), 0, -1):
-        target += one_second_later
-        print(print_info(f"{timedelta(seconds=remaining - 1)} remaining until next spray"), end="\r")
-        time.sleep((target - now()).total_seconds())
+    try:
+        for remaining in range(int(delay.total_seconds()), 0, -1):
+            target += one_second_later
+            print(print_info(f"{timedelta(seconds=remaining - 1)} remaining until next spray"), end="\r")
+            time.sleep((target - now()).total_seconds())
+    except KeyboardInterrupt:
+        return False
+    return True
+
 
 
 def get_utc_time():


### PR DESCRIPTION
Happy Hacktoberfest!

This PR fixes #9.

The problem was that adding `asyncio` signal handlers swallowed the `Ctrl+C`, and since the event loop wasn't running during the sleep loop, it never called `shutdown`.

I fixed it by unregistering the signals for the duration of the sleep loop.

Cheers,
Alex