### PR TITLE
fix: prevent negative sleep intervals. Closes #8.

### DIFF
--- a/core/utils/time.py
+++ b/core/utils/time.py
@@ -28,7 +28,8 @@ def countdown_timer(hours, minutes, seconds, now=datetime.now):
     for remaining in range(int(delay.total_seconds()), 0, -1):
         target += one_second_later
         print(print_info(f"{timedelta(seconds=remaining - 1)} remaining until next spray"), end="\r")
-        time.sleep((target - now()).total_seconds())
+        duration = (target - now()).total_seconds()
+        if duration > 0: time.sleep(duration)
 
 
 def get_utc_time():


### PR DESCRIPTION
This adds a check to prevent negative sleep duration in the interval countdown function.

It should hopefully be conflict-free with #17. I went with the fix that required the least amount of changes. The bug happens when `total_seconds()` returns a number very close to `1.0` and `target+1` is  in the future.

Cheers,
Alex