### PR TITLE
Show red if no passwords are found 👺

### DIFF
--- a/core/sprayers/owa.py
+++ b/core/sprayers/owa.py
@@ -57,7 +57,10 @@ class OWA:
             for username in self.valid_accounts:
                 account_file.write(username + '\n')
 
-        self.log.info(print_good(f"Dumped {len(self.valid_accounts)} valid accounts to owa_valid_accounts.txt"))
+        if len(self.valid_accounts) == 0:
+            self.log.info(print_bad(f"Dumped {len(self.valid_accounts)} valid accounts to owa_valid_accounts.txt"))
+        else:
+            self.log.info(print_good(f"Dumped {len(self.valid_accounts)} valid accounts to owa_valid_accounts.txt"))
 
     def get_owa_domain(self, url):
         # Stolen from https://github.com/dafthack/MailSniper


### PR DESCRIPTION
When a spray is finished, it shows a green plus even if no passwords are found.  This got my hopes up, and then after I realized I had no valid creds I then felt sad.  To spare others this emotional roller coaster I request that it be red when no passwords are found.  