### PR TITLE
* Parse positionally independent WWW-Authentication header

### DIFF
--- a/core/utils/ntlmdecoder.py
+++ b/core/utils/ntlmdecoder.py
@@ -214,7 +214,11 @@ def pretty_print_response(st):
 
 
 def ntlmdecode(authenticate_header):
-    _, st_raw = authenticate_header.split(',')[0].split()
+    for element in authenticate_header.split(','):
+        fields = element.split()
+        if fields[0] == 'NTLM':
+            st_raw = fields[1]
+            break
     try:
         st = base64.b64decode(st_raw)
     except Exception as e:


### PR DESCRIPTION
Most of the time, the `WWW-Authentication` header comes back looking like this:
```
'WWW-Authenticate': 'NTLM Tl<..snip...>A=, Negotiate, Basic realm="autodiscover.site.com"'
```

The original code handled this fine. However, sometimes the header can come back in the following form:

```
'Www-Authenticate': 'Negotiate, Basic realm="autodiscover.site.com", NTLM Tl<...snip...>A='
```

When this happens, the program would throw an error during parsing: `Error parsing internal domain name using OWA. This usually means OWA is being hosted on-prem or the target has a hybrid AD deployment`. 

This pull aims to reduce these false negatives by parsing until reaching the `NTLM` section of the header. 