### PR TITLE
Fixed bugs in HTML parsing

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ requests = "*"
 "boto3" = "*"
 requests-ntlm = "*"
 imapclient = "*"
+beautifulsoup4 = "*"
 
 [dev-packages]
 ipython = "*"

--- a/core/parsers/bing.py
+++ b/core/parsers/bing.py
@@ -1,15 +1,23 @@
-import lxml.html
+try: 
+    from BeautifulSoup import BeautifulSoup
+except ImportError:
+    from bs4 import BeautifulSoup
+
 from core.parsers.linkedin import linkedin_se_name_parser
 
 
 def bing(content):
     names = []
-    html = lxml.html.fromstring(content)
+    html = BeautifulSoup(content)
 
-    for result in html.xpath('//li[@class="b_algo"]/h2/a'):
-        text = ''.join(result.xpath('.//text()'))
+    try:
+        for result in html.body.findAll('li', attrs={'class':'b_algo'}):
+            text = result.find('h2').find('a').text
+            first, last = linkedin_se_name_parser(text)
+            if first or last:
+                names.append((first, last, text))
 
-        first, last = linkedin_se_name_parser(text)
-        names.append((first, last, text))
+    except AttributeError:
+        pass
 
     return names

--- a/core/parsers/google.py
+++ b/core/parsers/google.py
@@ -1,13 +1,18 @@
-import lxml.html
+try: 
+    from BeautifulSoup import BeautifulSoup
+except ImportError:
+    from bs4 import BeautifulSoup
+
 from core.parsers.linkedin import linkedin_se_name_parser
 
 
 def google(content):
     names = []
-    html = lxml.html.fromstring(content)
+    html = BeautifulSoup(content)
 
-    for text in html.xpath('//h3[@class="LC20lb"]//text()'):
+    for text in [e.text for e in html.body.findAll('h3', attrs={'class':'LC20lb'})]:
         first, last = linkedin_se_name_parser(text)
-        names.append((first, last, text))
+        if first or last:
+            names.append((first, last, text))
 
     return names

--- a/core/parsers/linkedin.py
+++ b/core/parsers/linkedin.py
@@ -3,7 +3,10 @@ def linkedin_se_name_parser(text):
     try:
         name, _ = text.split('-', 1)
     except ValueError:
-        name, _ = text.split('|', 1)
+        try:
+            name, _ = text.split('|', 1)
+        except ValueError:
+            return ('', '')
 
     parts = name.split()
     if len(parts) == 2:

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,4 @@ tornado==5.1.1
 urllib3==1.25.3 ; python_version >= '3.4'
 urwid==2.0.1
 wsproto==0.11.0
+beautifulsoup4==4.9.1


### PR DESCRIPTION
This PR addresses two bugs:
1) The google and bing lxml parsers fail to find any matches (the syntax is still correct, so heaven only knows why it stopped working).  Resolved by using BeautifulSoup, which still leverages lxml behind the scenes.
2) When the linkedin name parser fails to split on '|', it throws an exception and the entire page of results are lost.  Resolved by handling that AttributeError.

Cheers